### PR TITLE
added the motors section and fixed a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ Rebuilt: FRC game for the 2025–2026 season
 | Vision     | Helton   | Gray & Faulk |
 | Intake     | Morelli  | Gatlin |
 | Shooter    | Higgins  | Walsh |
-| Climber    | Olmstead | Mitchell |
+| Climber    | Olmsted | Mitchell |
 | Drivetrain | Siefert  | — |
 
+
+# Motors
+
+| Subsystem | Motor | Can IDs |
+| -- | -- | -- |
+| Intake | 1x CTR Minion | 10 - 19 |
+| Shooter | 2x CTR Minion | 20 - 29 |
+| Feeder | 1x Kraken x44 | 30 - 39 |
+| Climber | 2x Kraken x60 | 40 - 49 |


### PR DESCRIPTION
Corrected the spelling of 'Olmstead' to 'Olmsted' and added a new section for motors with details on subsystems and motor specifications as well as CAN IDs.