### PR TITLE
added the motors section and fixed a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt: FRC game for the 2025–2026 season
 | Vision     | Helton   | Gray & Faulk |
 | Intake     | Morelli  | Gatlin |
 | Shooter    | Higgins  | Walsh |
-| Climber    | Olmsted | Mitchell |
+| Climber    | Olmsted  | Mitchell |
 | Drivetrain | Siefert  | — |
 
 


### PR DESCRIPTION
Corrected the spelling of 'Olmstead' to 'Olmsted' and added a new section for motors with details on subsystems and motor specifications as well as CAN IDs.