### PR TITLE
Fix Can ID range for Turret and added Spindexer Subsystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Rebuilt: FRC game for the 2025–2026 season
 | Shooter    | Higgins  | Walsh |
 | Turret     | Helton   | Gray & Faulk |
 | Vision     | Helton   | Gray & Faulk |
+| Spindexer  | Morelli  | — |
 
 ## Motors
 
@@ -25,4 +26,5 @@ Rebuilt: FRC game for the 2025–2026 season
 | Shooter               | 2x CTR Minion                           | TalonFXS             | 20 - 29 |
 | Feeder                | 1x Kraken x44                           | TalonFX (_built-in_) | 30 - 39 |
 | Climber               | 2x Kraken x60                           | TalonFX (_built-in_) | 40 - 49 |
-| Turret                | 1x CTR Minion                           | TalonFXS             | 50 - 19 |
+| Turret                | 1x CTR Minion                           | TalonFXS             | 50 - 59 |
+| Spindexer             | 1x Kraken (TBD)                         | TalonFX (_built-in_) | 60 - 69 |


### PR DESCRIPTION
Added the subsystem for the spindexer, the part of the storage bucket that rotates the balls until they can be used in the shooter.